### PR TITLE
Update library for Node 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Next
+
+- **[Breaking change]** Update lib for Node 11. The new result only has
+  `url` (input), `isFileUrl` (boolean indicating a regular `file://` URL) and
+  an eventual `path`.
+
 # 0.1.2 (2018-10-20)
 
 - **[Fix]** Fix OS detection

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build status](https://img.shields.io/travis/demurgos/node-script-url/master.svg?maxAge=2592000)](https://travis-ci.org/demurgos/node-script-url)
 [![Codecov](https://codecov.io/gh/demurgos/node-script-url/branch/master/graph/badge.svg)](https://codecov.io/gh/demurgos/node-script-url)
 
-Helpers for Node's script URLs.
+Parse Node script URLs.
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-script-url",
   "version": "0.1.2",
-  "description": "Parser for Node's V8 script URL values",
+  "description": "Parse Node script URLs",
   "private": true,
   "main": "dist/lib/index",
   "types": "dist/lib/index.d.ts",
@@ -23,6 +23,9 @@
     "run": [
       "test"
     ]
+  },
+  "engines": {
+    "node": ">=10.12.0"
   },
   "author": "Charles Samborski <demurgos@demurgos.net> (https://demurgos.net)",
   "license": "MIT",

--- a/src/test/posix.spec.ts
+++ b/src/test/posix.spec.ts
@@ -1,55 +1,55 @@
 import chai from "chai";
-import { parsePosix, ScriptUrl } from "../lib";
+import isWindows from "is-windows";
+import { ParsedScriptUrl, parsePosix, parseSys } from "../lib";
 
 interface TestItem {
   url: string;
-  expected: ScriptUrl;
+  expected: ParsedScriptUrl;
 }
 
 const testItems: ReadonlyArray<TestItem> = [
   {
     url: "",
-    expected: {isRegularFile: false, scriptUrl: ""},
+    expected: {url: "", isFileUrl: false},
   },
   {
     url: "url.js",
-    expected: {isRegularFile: false, scriptUrl: "url.js"},
+    expected: {url: "url.js", isFileUrl: false},
   },
   {
     url: "internal/url.js",
-    expected: {isRegularFile: false, scriptUrl: "internal/url.js"},
+    expected: {url: "internal/url.js", isFileUrl: false},
   },
   {
     url: "internal/util/inspect.js",
-    expected: {isRegularFile: false, scriptUrl: "internal/util/inspect.js"},
+    expected: {url: "internal/util/inspect.js", isFileUrl: false},
   },
   {
     url: "/foo.js",
-    expected: {
-      isRegularFile: true,
-      scriptUrl: "/foo.js",
-      moduleType: "cjs",
-      url: "file:///foo.js",
-      path: "/foo.js",
-    },
+    expected: {url: "/foo.js", isFileUrl: false},
   },
   {
     url: "file:///foo.mjs",
-    expected: {
-      isRegularFile: true,
-      scriptUrl: "file:///foo.mjs",
-      moduleType: "esm",
-      url: "file:///foo.mjs",
-      path: "/foo.mjs",
-    },
+    expected: {url: "file:///foo.mjs", isFileUrl: true, path: "/foo.mjs"},
   },
 ];
 
 describe("parsePosix", () => {
   for (const {url, expected} of testItems) {
     it(JSON.stringify(url), () => {
-      const actual: ScriptUrl = parsePosix(url);
+      const actual: ParsedScriptUrl = parsePosix(url);
       chai.assert.deepEqual(actual, expected);
     });
   }
 });
+
+function parseSysSuite() {
+  for (const {url, expected} of testItems) {
+    it(JSON.stringify(url), () => {
+      const actual: ParsedScriptUrl = parseSys(url);
+      chai.assert.deepEqual(actual, expected);
+    });
+  }
+}
+
+(isWindows() ? describe.skip : describe)("parseSys (posix)", parseSysSuite);

--- a/src/test/windows.spec.ts
+++ b/src/test/windows.spec.ts
@@ -1,55 +1,55 @@
 import chai from "chai";
-import { parseWindows, ScriptUrl } from "../lib";
+import isWindows from "is-windows";
+import { ParsedScriptUrl, parseSys, parseWindows } from "../lib";
 
 interface TestItem {
   url: string;
-  expected: ScriptUrl;
+  expected: ParsedScriptUrl;
 }
 
 const testItems: ReadonlyArray<TestItem> = [
   {
     url: "",
-    expected: {isRegularFile: false, scriptUrl: ""},
+    expected: {url: "", isFileUrl: false},
   },
   {
     url: "url.js",
-    expected: {isRegularFile: false, scriptUrl: "url.js"},
+    expected: {url: "url.js", isFileUrl: false},
   },
   {
     url: "internal/url.js",
-    expected: {isRegularFile: false, scriptUrl: "internal/url.js"},
+    expected: {url: "internal/url.js", isFileUrl: false},
   },
   {
     url: "internal/util/inspect.js",
-    expected: {isRegularFile: false, scriptUrl: "internal/util/inspect.js"},
+    expected: {url: "internal/util/inspect.js", isFileUrl: false},
   },
   {
     url: "C:\\foo.js",
-    expected: {
-      isRegularFile: true,
-      scriptUrl: "C:\\foo.js",
-      moduleType: "cjs",
-      url: "file:///C:/foo.js",
-      path: "C:\\foo.js",
-    },
+    expected: {url: "C:\\foo.js", isFileUrl: false},
   },
   {
     url: "file:///C:/foo.mjs",
-    expected: {
-      isRegularFile: true,
-      scriptUrl: "file:///C:/foo.mjs",
-      moduleType: "esm",
-      url: "file:///C:/foo.mjs",
-      path: "C:\\foo.mjs",
-    },
+    expected: {url: "file:///C:/foo.mjs", isFileUrl: true, path: "C:\\foo.mjs"},
   },
 ];
 
 describe("parseWindows", () => {
   for (const {url, expected} of testItems) {
     it(JSON.stringify(url), () => {
-      const actual: ScriptUrl = parseWindows(url);
+      const actual: ParsedScriptUrl = parseWindows(url);
       chai.assert.deepEqual(actual, expected);
     });
   }
 });
+
+function parseSysSuite() {
+  for (const {url, expected} of testItems) {
+    it(JSON.stringify(url), () => {
+      const actual: ParsedScriptUrl = parseSys(url);
+      chai.assert.deepEqual(actual, expected);
+    });
+  }
+}
+
+(isWindows() ? describe : describe.skip)("parseSys (windows)", parseSysSuite);


### PR DESCRIPTION
The new result only has `url` (input), `isFileUrl` (boolean indicating a regular `file://` URL) and an eventual `path`.