### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.2.0 (2018-11-27)
 
 - **[Breaking change]** Update lib for Node 11. The new result only has
   `url` (input), `isFileUrl` (boolean indicating a regular `file://` URL) and

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-script-url",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Parse Node script URLs",
   "private": true,
   "main": "dist/lib/index",


### PR DESCRIPTION
- **[Breaking change]** Update lib for Node 11. The new result only has `url` (input), `isFileUrl` (boolean indicating a regular `file://` URL) and an eventual `path`.